### PR TITLE
feature: subBanner 컴포넌트 추가

### DIFF
--- a/src/components/common/SubBanner/index.jsx
+++ b/src/components/common/SubBanner/index.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import styled from 'styled-components';
+import splite from '../../../img/zetaplan_splite.png';
+
+const SubBanner = ({title, img}) => {
+  return (
+    <SubBannerContainer img={`${img}`}>
+      <SubBannerTextContainer>
+        <div className='leftBracket'></div>
+        <p dangerouslySetInnerHTML={{__html: title}}></p>
+        <div className='rightBracket'></div>
+      </SubBannerTextContainer>
+    </SubBannerContainer>
+  );
+};
+
+export default SubBanner;
+
+const SubBannerContainer = styled.div`
+  width: 100%;
+  height: 620px;
+  background: url(${props => props.img}) no-repeat;
+  background-size: cover;
+  position: relative;
+`
+
+const SubBannerTextContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: absolute;
+  width: auto;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  .leftBracket {
+    background: url(${splite}) no-repeat -5px -190px;
+    background-size: 599px 280px;
+    width: 20px;
+    min-width: 20px;
+    height: 72px;
+    margin-right: 50px;
+  }
+
+  p {
+    @import 'https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&family=Noto+Sans+KR:wght@400;500;700;900&family=Roboto:wght@700&display=swap';
+    font-size: 4.5rem;
+    font-weight: bold;
+    line-height: 1.3;
+    color: #fff;
+    font-family: 'Noto Sans KR', sans-serif;
+    text-align: center;
+  }
+
+  .rightBracket {
+    background: url(${splite}) no-repeat -79px -190px;
+	  background-size: 599px 280px;
+    width: 20px;
+    min-width: 20px;
+	  height: 72px;
+    margin-left: 50px;
+  }
+`


### PR DESCRIPTION
## 내용
1. subBanner 컴포넌트 추가
2. 각자 세부페이지에서 컴포넌트 부른 다음에 title이랑 img props로 내려야 됩니다.
3. title에 엔터가 있을 경우, <br /> 태그 이용하면 됩니다. (컴포넌트에 dangerouslySetInnerHTML 설정되어 있음)

## 스크린샷
- 아래 스크린샷은 Qna 페이지에서 불러오는 방법을 예시로 찍었습니다.
- title 변수에 담기는 텍스트와 import subBg에서 불러오는 것만 각자 세부페이지에 해당하는 것을 넣어주시면 됩니다.
![스크린샷 2022-07-14 오전 9 35 24](https://user-images.githubusercontent.com/86041335/178861207-ff559a38-5d73-4ac8-af9c-7097c92b4c51.png)

